### PR TITLE
Systime

### DIFF
--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -13,10 +13,12 @@ import std.typecons : Nullable;
 
 /// Converts Nullable!T to Value
 Value toValue(T)(T v)
-    if (is(T == Nullable!R, R))
+if (is(T == Nullable!R, R))
 {
-    if (v.isNull) return Value(null, detectOidTypeFromNative!(TemplateArgsOf!T[0]), true);
-    return toValue(v.get);
+    if (v.isNull)
+        return Value(ValueFormat.BINARY, detectOidTypeFromNative!(TemplateArgsOf!T[0]));
+    else
+        return toValue(v.get);
 }
 
 Value toValue(T)(T v)
@@ -56,6 +58,7 @@ Value toValue(T)(T v)
 if (is(Unqual!T == Date))
 {
     auto days = cast(int)(v - POSTGRES_EPOCH_DATE).total!"days";
+
     return Value(nativeToBigEndian(days).dup, OidType.Date, false);
 }
 
@@ -63,7 +66,8 @@ if (is(Unqual!T == Date))
 Value toValue(T)(T v)
 if (is(Unqual!T == TimeOfDay))
 {
-    long ms = (v.second + v.minute*60L + v.hour*3_600L)*1_000_000;
+    long ms = ((60L * v.hour + v.minute) * 60 + v.second) * 1_000_000;
+
     return Value(nativeToBigEndian(ms).dup, OidType.Time, false);
 }
 

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -57,7 +57,9 @@ if (!is(T == Nullable!R, R))
 Value toValue(T)(T v)
 if (is(Unqual!T == Date))
 {
-    auto days = cast(int)(v - POSTGRES_EPOCH_DATE).total!"days";
+    import std.conv: to;
+
+    auto days = (v - POSTGRES_EPOCH_DATE).total!"days".to!int;
 
     return Value(nativeToBigEndian(days).dup, OidType.Date, false);
 }

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -83,7 +83,8 @@ if (is(Unqual!T == TimeStampWithoutTZ))
 Value toValue(T)(T v)
 if (is(Unqual!T == SysTime))
 {
-    auto us = (v - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
+    long us = (v - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
+
     return Value(nativeToBigEndian(us).dup, OidType.TimeStampWithZone, false);
 }
 

--- a/src/dpq2/conv/from_d_types.d
+++ b/src/dpq2/conv/from_d_types.d
@@ -66,16 +66,18 @@ if (is(Unqual!T == Date))
 Value toValue(T)(T v)
 if (is(Unqual!T == TimeOfDay))
 {
-    long ms = ((60L * v.hour + v.minute) * 60 + v.second) * 1_000_000;
+    long us = ((60L * v.hour + v.minute) * 60 + v.second) * 1_000_000;
 
-    return Value(nativeToBigEndian(ms).dup, OidType.Time, false);
+    return Value(nativeToBigEndian(us).dup, OidType.Time, false);
 }
 
 /// Constructs Value from TimeStampWithoutTZ
 Value toValue(T)(T v)
 if (is(Unqual!T == TimeStampWithoutTZ))
 {
-    auto us = (SysTime(v.dateTime, v.fracSec, UTC()) - SysTime(POSTGRES_EPOCH_DATE, UTC())).total!"usecs";
+    long j = v.dateTime.julianDay - POSTGRES_EPOCH_DATE.julianDay; // FIXME: use POSTGRES_EPOCH_JDATE here
+    long us = (((j * 24 + v.hour) * 60 + v.minute) * 60 + v.second) * 1_000_000 + v.fracSec.total!"usecs";
+
     return Value(nativeToBigEndian(us).dup, OidType.TimeStamp, false);
 }
 

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -86,10 +86,7 @@ if( is( T == TimeStampWithoutTZ ) )
 }
 
 /++
-    Structure to represent PostgreSQL's Timestamp without time zone type.
-    Conversions between timestamp without time zone and timestamp with time zone normally assume that
-    the timestamp without time zone value should be taken or given as timezone local time.
-    A different time zone can be specified for the conversion using AT TIME ZONE.
+    Structure to represent PostgreSQL Timestamp with/without time zone
 +/
 struct TimeStampWithoutTZ
 {

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -183,7 +183,7 @@ void j2date(int jd, out int year, out int month, out int day)
 {
     enum MONTHS_PER_YEAR = 12;
     enum POSTGRES_EPOCH_JDATE = POSTGRES_EPOCH_DATE.julianDay;
-    static assert(POSTGRES_EPOCH_JDATE == 2_451_545);
+    static assert(POSTGRES_EPOCH_JDATE == 2_451_545); // value from Postgres code
 
     jd += POSTGRES_EPOCH_JDATE;
 

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -238,7 +238,7 @@ else
     }
 }
 
-TimeOfDay time2tm(TimeADT time) pure
+TimeOfDay time2tm(TimeADT time)
 {
     /*
         TODO: Have_Int64_TimeStamp should be removed from dpq2 due to

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -101,6 +101,7 @@ struct TimeStampWithoutTZ
     invariant()
     {
         import std.conv : to;
+
         assert(fracSec >= Duration.zero, fracSec.to!string);
         assert(fracSec < 1.seconds, fracSec.to!string);
     }
@@ -239,8 +240,16 @@ else
     }
 }
 
-TimeOfDay time2tm(TimeADT time)
+TimeOfDay time2tm(TimeADT time) pure
 {
+    /*
+        TODO: Have_Int64_TimeStamp should be removed from dpq2 due to
+        commit "Remove now-dead code for !HAVE_INT64_TIMESTAMP." in
+        Postgres code committed on 24 Feb 2017 b9d092c962ea3262930e3c31a8c3d79b66ce9d43
+
+        Discussion: https://postgr.es/m/26788.1487455319@sss.pgh.pa.us
+    */
+
     version(Have_Int64_TimeStamp)
     {
         immutable long USECS_PER_HOUR  = 3600000000;

--- a/src/dpq2/conv/time.d
+++ b/src/dpq2/conv/time.d
@@ -182,7 +182,8 @@ TimeStampWithoutTZ raw_pg_tm2nativeTime(pg_tm tm, fsec_t ts)
 void j2date(int jd, out int year, out int month, out int day)
 {
     enum MONTHS_PER_YEAR = 12;
-    enum POSTGRES_EPOCH_JDATE = 2_451_545;
+    enum POSTGRES_EPOCH_JDATE = POSTGRES_EPOCH_DATE.julianDay;
+    static assert(POSTGRES_EPOCH_JDATE == 2_451_545);
 
     jd += POSTGRES_EPOCH_JDATE;
 

--- a/src/dpq2/conv/to_d_types.d
+++ b/src/dpq2/conv/to_d_types.d
@@ -191,7 +191,6 @@ public void _integration_test( string connParam ) @system
         void testIt(T)(T nativeValue, string pgType, string pgValue)
         {
             import std.algorithm : strip;
-            import std.format : format;
             import std.string : representation;
 
             // test string to native conversion


### PR DESCRIPTION
- Nullable converter uses NULL-Value ctor
- Date long to int conv fixed
- ms->us, convertation code changed for TimeOfDay (copy'n'paste from Postgres src)
- TimeStampWithoutTZ conversation: SysTime removed, calculations added for increase accuracy
- JDATA calculation added
- some comments

Nothing fundamental did not touched - we will do it after your second patch